### PR TITLE
Adds dummy events to not have an empty mobile view

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { Calendar, momentLocalizer } from "react-big-calendar";
-import { Alert, AlertIcon } from "@chakra-ui/core";
 import moment from "moment";
 import "moment/locale/es";
 import "react-big-calendar/lib/css/react-big-calendar.css";
@@ -44,25 +43,20 @@ const MyCalendar = (props) => {
   max.setHours(23, 0, 0);
 
   function eventPropsGetter(event, start, end, isSelected) {
-    var style = {
-      backgroundColor: "#9993",
+    const style = {
+      borderWidth: "thick",
+      color: "#1f1f1f",
       borderLeftColor: event.color,
-      borderRightColor: '#0000',
-      borderBottomColor: '#0000',
-      borderTopColor: '#0000',
-      borderWidth: 'thick',
-      color: '#1f1f1f',
-      textAlign: 'right'
     };
-    if (useAgenda) {
-      delete style['backgroundColor']
-      delete style['borderRightColor']
-      delete style['borderBottomColor']
-      delete style['borderTopColor']
-      delete style['textAlign']
-    }
+    const calendarWeekStyle = {
+      textAlign: "right",
+      backgroundColor: "#9993",
+      borderRightColor: "#0000",
+      borderBottomColor: "#0000",
+      borderTopColor: "#0000",
+    };
     return {
-      style: style
+      style: useAgenda ? style : { ...style, ...calendarWeekStyle },
     };
   }
 
@@ -78,13 +72,6 @@ const MyCalendar = (props) => {
       defaultDate={new Date(2018, 0, 1)} // Monday
       events={events}
       eventPropGetter={eventPropsGetter}
-      messages={{
-        noEventsInRange:
-          <Alert status="info" variant="left-accent">
-            <AlertIcon />
-              No hay materias seleccionadas
-          </Alert>
-      }}
       components={{
         event: MateriaEvent
       }}
@@ -92,6 +79,5 @@ const MyCalendar = (props) => {
     />
   );
 };
-
 
 export default MyCalendar;

--- a/src/components/CalendarAgenda.js
+++ b/src/components/CalendarAgenda.js
@@ -18,6 +18,37 @@ function Agenda({
   const contentRef = useRef(null)
   const tbodyRef = useRef(null)
 
+
+  const coveredDays = events.map((e) => e.start.getDay());
+  const notCoveredDays = [0, 1, 2, 3, 4, 5, 6].filter(
+    (d) => !coveredDays.includes(d)
+  );
+  const dummyEvents = notCoveredDays
+    .map((i) => [
+      {
+        start: new Date(2018, 0, i, 7),
+        end: new Date(2018, 0, i, 11),
+        title: "",
+      },
+      {
+        start: new Date(2018, 0, i, 11),
+        end: new Date(2018, 0, i, 15),
+        title: "",
+      },
+      {
+        start: new Date(2018, 0, i, 15),
+        end: new Date(2018, 0, i, 19),
+        title: "",
+      },
+      {
+        start: new Date(2018, 0, i, 19),
+        end: new Date(2018, 0, i, 23),
+        title: "",
+      },
+    ])
+    .flat();
+  events = [...events, ...dummyEvents]
+
   const renderDay = (day, events, dayKey) => {
     const { event: Event, date: AgendaDate } = components
 


### PR DESCRIPTION
On each event change, if there are no events "covering" the week days, it fills that day with some dummy events.

On entering the page, there are no events, so no day from Monday to Saturday is covered. This fills the view with 4 dummy events:

![image](https://user-images.githubusercontent.com/25667102/92529149-65cbd380-f200-11ea-974e-fe9c665f168a.png)


Then, on changing some events (adding a Wednesday and Friday class), it removes the dummy events for those days, but keeps the rest:

![image](https://user-images.githubusercontent.com/25667102/92529129-5e0c2f00-f200-11ea-9f53-3db3f187db0a.png)



This only applies to the Agenda view (the mobile view).