### PR TITLE
Fix horario F3

### DIFF
--- a/src/data/horarios.js
+++ b/src/data/horarios.js
@@ -7622,13 +7622,13 @@ export const data = {
       "clases": [
         {
           "dia": 2,
-          "inicio": "13:00",
-          "fin": "19:00"
+          "inicio": "14:00",
+          "fin": "17:00"
         },
         {
           "dia": 4,
           "inicio": "14:00",
-          "fin": "18:00"
+          "fin": "17:00"
         }
       ]
     },


### PR DESCRIPTION
El horario de "82.03 / 62.05 Física III - Curso 1 - Ozols" es de 14 a 17, está mal en la oferta (ya avisé al Depto).

https://campus.fi.uba.ar/course/view.php?id=1521

Si fuera de 13 a 19, renunciaríamos todos los docentes.

Hablando en serio, ya hubo gente que nos consultó por esto, ya que por más que sean del plan nuevo (82.03), figura primero el plan viejo (62.05), tanto en la oferta académica como acá. Entonces se asustan. Para mi gusto, sería más usable que figure primero el plan nuevo en todos los casos, porque la gran mayoría hoy tiene el plan nuevo (calculo que en todas las carreras). La única contra de hacer eso es que se podría decir que se incurriría en un leve edadismo.