### PR TITLE
Add sugerencias toggling feature

### DIFF
--- a/src/components/MateriasDrawer.js
+++ b/src/components/MateriasDrawer.js
@@ -251,8 +251,15 @@ const MateriasDrawer = (props) => {
                   bg="primary.400"
                   onClick={() => {
                     onClose();
-                    toast.close(bugToast.current);
+                    if (toast.isActive(bugToast.current)) {
+                      toast.close(bugToast.current);
+                      return;
+                    }
                     return (bugToast.current = toast({
+                      status: "info",
+                      position: "bottom",
+                      duration: null,
+                      isClosable: true,
                       render: (props) => (
                         <Alert
                           borderRadius={6}
@@ -348,11 +355,7 @@ const MateriasDrawer = (props) => {
                             top="8px"
                           />
                         </Alert>
-                      ),
-                      status: "info",
-                      position: "bottom",
-                      duration: null,
-                      isClosable: true,
+                      )
                     }));
                   }}
                 >


### PR DESCRIPTION
Hola buen dia, es el mismo cambio que en el repo de [FIUBA-map](https://github.com/FdelMazo/FIUBA-Map/pull/199).

Agrego la funcionalidad de cerrar el toast de sugerencias con el mismo boton con que se abre.
Reacomodo las propiedades al comienzo del tag del toast.