### PR TITLE
Add keyboard support

### DIFF
--- a/src/components/SelectCurso.js
+++ b/src/components/SelectCurso.js
@@ -58,11 +58,16 @@ const SelectCurso = ({ codigo }) => {
 
   const allItemsBlocked = items.every((item) => isBlocked(item.codigo));
 
-  const { isOpen, getItemProps, getToggleButtonProps, getMenuProps } =
-    useSelect({
-      stateReducer,
-      items,
-    });
+  const {
+    isOpen,
+    getItemProps,
+    getToggleButtonProps,
+    highlightedIndex,
+    getMenuProps,
+  } = useSelect({
+    stateReducer,
+    items,
+  });
 
   return (
     <>
@@ -165,7 +170,7 @@ const SelectCurso = ({ codigo }) => {
             >
               <Box
                 py={1}
-                _hover={{ bg: "hovercolor" }}
+                bg={highlightedIndex === index && "hovercolor"}
                 color={isActive ? color : "gray.200"}
                 cursor="pointer"
                 fontSize="xs"

--- a/src/components/SelectCurso.js
+++ b/src/components/SelectCurso.js
@@ -17,9 +17,9 @@ import {
 } from "@chakra-ui/react";
 import { useSelect } from "downshift";
 import React from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { DataContext } from "../DataContext";
-import { getColor } from "../utils";
-import { stateReducer } from "../utils";
+import { getColor, stateReducer } from "../utils";
 
 const INICIALES_SEMANA = ["D", "L", "M", "X", "J", "V", "S"];
 
@@ -67,6 +67,12 @@ const SelectCurso = ({ codigo }) => {
   } = useSelect({
     stateReducer,
     items,
+  });
+
+  useHotkeys("space, enter", () => {
+    if (highlightedIndex === -1) return;
+    const curso = items[highlightedIndex];
+    toggleCurso(curso.codigo);
   });
 
   return (

--- a/src/components/SelectExtra.js
+++ b/src/components/SelectExtra.js
@@ -15,12 +15,13 @@ import {
   Flex,
   IconButton,
   List,
-  Tooltip,
   Text,
+  Tooltip,
   useEditableControls,
 } from "@chakra-ui/react";
 import { useSelect } from "downshift";
 import React from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { DataContext } from "../DataContext";
 import { getColor, stateReducer } from "../utils";
 
@@ -43,6 +44,12 @@ const SelectExtra = () => {
   } = useSelect({
     stateReducer,
     items: extraEvents,
+  });
+
+  useHotkeys("space, enter", () => {
+    if (highlightedIndex === -1) return;
+    const event = extraEvents[highlightedIndex];
+    toggleExtra(event.id);
   });
 
   return (

--- a/src/components/SelectExtra.js
+++ b/src/components/SelectExtra.js
@@ -34,11 +34,16 @@ const SelectExtra = () => {
     removeAllExtra,
   } = React.useContext(DataContext);
 
-  const { isOpen, getItemProps, getToggleButtonProps, getMenuProps } =
-    useSelect({
-      stateReducer,
-      items: extraEvents,
-    });
+  const {
+    isOpen,
+    getItemProps,
+    getToggleButtonProps,
+    getMenuProps,
+    highlightedIndex,
+  } = useSelect({
+    stateReducer,
+    items: extraEvents,
+  });
 
   return (
     <>
@@ -99,7 +104,7 @@ const SelectExtra = () => {
           return (
             <Box
               py={1}
-              _hover={{ bg: "hovercolor" }}
+              bg={highlightedIndex === index && "hovercolor"}
               color={isActive ? color : "gray.200"}
               cursor="pointer"
               fontSize="xs"

--- a/src/components/SelectMateria.js
+++ b/src/components/SelectMateria.js
@@ -32,6 +32,7 @@ const SelectMateria = ({ materiasToShow }) => {
     getMenuProps,
     getInputProps,
     getItemProps,
+    highlightedIndex,
   } = useCombobox({
     items: inputItems,
     itemToString: (item) => search,
@@ -83,7 +84,7 @@ const SelectMateria = ({ materiasToShow }) => {
             .map((materia, index) => (
               <Box
                 borderRadius={5}
-                _hover={{ bg: "hovercolor" }}
+                bg={highlightedIndex === index && "hovercolor"}
                 color={
                   selectedMaterias.includes(materia.codigo)
                     ? "primary.500"

--- a/src/components/SelectMateria.js
+++ b/src/components/SelectMateria.js
@@ -8,6 +8,7 @@ import {
 } from "@chakra-ui/react";
 import { useCombobox } from "downshift";
 import React from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { DataContext } from "../DataContext";
 import { stateReducer } from "../utils";
 
@@ -46,6 +47,16 @@ const SelectMateria = ({ materiasToShow }) => {
     },
     stateReducer,
   });
+
+  useHotkeys(
+    "enter",
+    () => {
+      if (highlightedIndex === -1) return;
+      const materia = inputItems[highlightedIndex];
+      toggleMateria(materia.codigo);
+    },
+    { enableOnFormTags: ["input"] },
+  );
 
   return (
     <>


### PR DESCRIPTION
Para agregarle accesibilidad a la app, quiero poder lograr el keyboard support que tiene downshift: con las flechitas elegis el elemento, y con space o enter lo seleccionas/deseleccionas.

No pude agregar la funcionalidad nativa de downshift (trae problemas en mobile) asi que la recree a mano con `useHotkeys`. 