### PR TITLE
Allow periodo lectivo selection on horarios SIU

### DIFF
--- a/src/DataContext.js
+++ b/src/DataContext.js
@@ -163,23 +163,22 @@ const Data = () => {
     initialExtraEvents,
   );
 
-  const applyHorariosSIU = async (rawdata) => {
-    let horarios;
+  const getPeriodosSIU = (rawdata) => {
+    let periodos;
     try {
-      horarios = await parseSIU(rawdata);
-      if (!horarios.materias.length || !horarios.cursos.length) {
-        throw new Error("No se encontraron cursos en el archivo");
+      periodos = parseSIU(rawdata);
+      if (!periodos.length) {
+        throw new Error("No se encontraron horarios en el archivo");
       }
     } catch (e) {
       console.warn(e);
       throw new Error("Error al parsear los horarios del SIU");
     }
+    return periodos;
+  };
 
-    // Limpiamos todas las materias seleccionadas por el usuario
-    selectedMaterias.forEach((codigo) => {
-      toggleMateria(codigo);
-    });
-    setHorariosSIU(horarios);
+  const applyHorariosSIU = (periodo) => {
+    setHorariosSIU(periodo);
   };
 
   const removeHorariosSIU = async () => {
@@ -399,6 +398,7 @@ const Data = () => {
     applyHorariosSIU,
     removeHorariosSIU,
     getters,
+    getPeriodosSIU,
   };
 };
 

--- a/src/DataContext.js
+++ b/src/DataContext.js
@@ -29,18 +29,18 @@ const Data = () => {
   // Getters que verifican contra el SIU del usuario
   const getters = React.useMemo(() => {
     const getMateria = (codigo) => {
-      return horariosSIU.materias.find((m) => m.codigo === codigo);
+      return horariosSIU?.materias.find((m) => m.codigo === codigo);
     };
 
     const getCurso = (codigo) => {
-      return horariosSIU.cursos.find((c) => c.codigo === codigo);
+      return horariosSIU?.cursos.find((c) => c.codigo === codigo);
     };
 
     const getCursosMateria = (codigoMateria) => {
-      const cursos = horariosSIU.materias.find(
+      const cursos = horariosSIU?.materias.find(
         (m) => m.codigo === codigoMateria,
       ).cursos;
-      return cursos.map(getCurso);
+      return cursos?.map(getCurso) || [];
     };
 
     return {
@@ -52,7 +52,7 @@ const Data = () => {
 
   // ESTADO 1: Las materias tickeadas por el usuario para verlas en el drawer
   const [selectedMaterias, setSelectedMaterias] = useImmer(() =>
-    initialSelectedMaterias(getters),
+    initialSelectedMaterias(),
   );
 
   // ESTADO 2: Las tabs y el nombre que el usuario les puso
@@ -133,7 +133,7 @@ const Data = () => {
   const [tabEvents, tabEventsDispatch] = useImmerReducer(
     tabEventsReducer,
     { 0: { cursos: [], extra: [] } },
-    (defvalue) => initialTabEvents(defvalue, getters),
+    (defvalue) => initialTabEvents(defvalue),
   );
 
   // ESTADO 4: Los horarios extracurriculares que agrega el usuario, y el nombre que les puso
@@ -182,7 +182,7 @@ const Data = () => {
     setHorariosSIU(horarios);
   };
 
-  const removeHorariosSIU = () => {
+  const removeHorariosSIU = async () => {
     // Limpiamos todas las materias seleccionadas por el usuario
     selectedMaterias.forEach((codigo) => {
       toggleMateria(codigo);

--- a/src/components/ManualUploadModal.js
+++ b/src/components/ManualUploadModal.js
@@ -30,7 +30,7 @@ const ManualUploadModal = ({ isOpen, onClose }) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="lg">
       <ModalOverlay />
-      <ModalContent borderWidth="2px" borderColor="primary.500" color="black">
+      <ModalContent borderWidth="2px" borderColor="primary.500">
         <ModalHeader>Importar horarios del SIU</ModalHeader>
         <ModalCloseButton />
         <ModalBody>

--- a/src/components/MateriasDrawer.js
+++ b/src/components/MateriasDrawer.js
@@ -75,8 +75,8 @@ const MateriasDrawer = (props) => {
               w="100%"
               rightIcon={<DeleteIcon />}
               colorScheme="red"
-              onClick={() => {
-                removeHorariosSIU();
+              onClick={async () => {
+                await removeHorariosSIU();
                 onClose();
               }}
             >

--- a/src/components/TabSystem.js
+++ b/src/components/TabSystem.js
@@ -12,18 +12,32 @@ import {
   Flex,
   IconButton,
   LightMode,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverFooter,
+  PopoverTrigger,
   Tab,
   Tabs,
-  useToast,
+  Text,
   useTab,
+  useToast,
 } from "@chakra-ui/react";
 import "moment/locale/es";
 import React from "react";
 import { DataContext } from "../DataContext";
 
 const TabSystem = (props) => {
-  const { activeTabId, tabs, selectTab, addTab, readOnly, setReadOnly } =
-    React.useContext(DataContext);
+  const {
+    activeTabId,
+    tabs,
+    selectTab,
+    addTab,
+    readOnly,
+    setReadOnly,
+    horariosSIU,
+  } = React.useContext(DataContext);
   const toast = useToast();
   const inputref = React.useRef(null);
 

--- a/src/components/TabSystem.js
+++ b/src/components/TabSystem.js
@@ -145,6 +145,33 @@ const TabSystem = (props) => {
           )}
         </Flex>
       </Tabs>
+      {horariosSIU && (
+        <Box alignSelf="center" px={4}>
+          <Popover placement="bottom" trigger="hover">
+            <PopoverTrigger>
+              <Text textAlign="right">
+                <strong>Usando horarios del SIU</strong>
+                <br />
+                {horariosSIU.periodo}
+              </Text>
+            </PopoverTrigger>
+            <PopoverContent borderColor="primary.500" mr={2}>
+              <PopoverArrow bg="primary.500" />
+              <PopoverBody>
+                Acordate que el SIU también puede actualizar sus horarios sin
+                aviso previo. Si estás por inscribirte a materias, es
+                recomendable que re-cargues los horarios.
+              </PopoverBody>
+              <PopoverFooter fontSize="sm">
+                Horarios cargados el{" "}
+                <strong>
+                  {new Date(horariosSIU.timestamp).toLocaleString()}
+                </strong>
+              </PopoverFooter>
+            </PopoverContent>
+          </Popover>
+        </Box>
+      )}
     </Flex>
   );
 };

--- a/src/siuparser.js
+++ b/src/siuparser.js
@@ -1,79 +1,98 @@
-export async function parseSIU(rawdata) {
+const SEMANA = [
+  "Domingo",
+  "Lunes",
+  "Martes",
+  "Miércoles",
+  "Jueves",
+  "Viernes",
+  "Sábado",
+];
+
+export function parseSIU(rawdata) {
   // Asegurarse:
   // - no agregar ningun curso sin clases
   // - no agregar ninguna materia sin cursos asociados
+  // - no agregar periodos sin materias
 
-  const pattern = /Actividad:(.*?)(?=(Actividad:|$))/gs;
-  const matches = rawdata.matchAll(pattern);
-  const semana = [
-    "Domingo",
-    "Lunes",
-    "Martes",
-    "Miércoles",
-    "Jueves",
-    "Viernes",
-    "Sábado",
-  ];
+  const result = [];
 
-  const result = {
-    materias: [],
-    cursos: [],
-  };
-  for (const match of matches) {
-    const actividad = match[0];
-    const materiaPattern = /Actividad:(.*?) \((.+?)\)/;
-    const materiaMatch = actividad.match(materiaPattern);
-    if (!materiaMatch) {
-      continue;
-    }
-    const materia = {
-      nombre: materiaMatch[1],
-      codigo: materiaMatch[2],
+  const periodoPattern =
+    /Período lectivo: ([^\n]+)\n((?!Período lectivo:)[\s\S])*?(?=(Período lectivo:|$))/g;
+  const materiaPattern =
+    /Actividad: ([^\n]+) \((\d+)\)\n((?!Actividad:)[\s\S])*?(?=(Actividad:|$))/g;
+  const cursosPattern =
+    /Comisión: ([^\n]+)[\s\S]*?Docentes: ([^\n]+)[\s\S]*?Tipo de clase\s+Día\s+Horario\s+Aula([\s\S]*?)(?=(Comisión:|$))/g;
+
+  const periodos = [];
+  for (const periodoMatch of rawdata.matchAll(periodoPattern)) {
+    const periodoFullText = periodoMatch[0];
+    const periodoNombre = periodoMatch[1];
+    periodos.push({
+      periodo: periodoNombre,
+      raw: periodoFullText,
+      materias: [],
       cursos: [],
-    };
+    });
+  }
 
-    const cursosPattern =
-      /Comisión: ([^\n]+)[\s\S]*?Docentes: ([^\n]+)[\s\S]*?Tipo de clase\s+Día\s+Horario\s+Aula([\s\S]*?)(?=(Comisión:|$))/g;
+  for (let periodo of periodos) {
+    for (const materiaMatch of periodo.raw.matchAll(materiaPattern)) {
+      const materiaFullText = materiaMatch[0];
+      const materia = {
+        nombre: materiaMatch[1],
+        codigo: materiaMatch[2],
+        cursos: [],
+      };
 
-    let matchCurso;
-    while ((matchCurso = cursosPattern.exec(actividad)) !== null) {
-      const codigo = `${materia.codigo}-${matchCurso[1]}`;
-      let docentes = matchCurso[2].trim().replace(/\(.*?\)/g, "");
+      for (const cursoMatch of materiaFullText.matchAll(cursosPattern)) {
+        const cursoCodigo = `${materia.codigo}-${cursoMatch[1]}`;
+        const cursoDocentes = cursoMatch[2].trim().replace(/\(.*?\)/g, "");
 
-      const clases = [];
-      for (let claseLine of matchCurso[3].trim().split("\n")) {
-        if (
-          matchCurso[3].includes("Sin definir") ||
-          !claseLine.includes("\t")
-        ) {
+        const clases = [];
+        for (let claseLine of cursoMatch[3].trim().split("\n")) {
+          if (claseLine.includes("Sin definir") || !claseLine.includes("\t")) {
+            continue;
+          }
+
+          // eslint-disable-next-line no-unused-vars
+          const [_tipo, dia, horario, _aula] = claseLine.split("\t");
+          const [inicio, fin] = horario.split(" a ");
+          const clase = {
+            dia: SEMANA.indexOf(dia),
+            inicio,
+            fin,
+          };
+          clases.push(clase);
+        }
+
+        if (clases.length === 0) {
           continue;
         }
-        // eslint-disable-next-line no-unused-vars
-        const [_tipo, dia, horario, _aula] = claseLine.split("\t");
-        const [inicio, fin] = horario.split(" a ");
-        const clase = {
-          dia: semana.indexOf(dia),
-          inicio,
-          fin,
-        };
-        clases.push(clase);
+
+        periodo.cursos.push({
+          materia: materia.codigo,
+          codigo: cursoCodigo,
+          docentes: cursoDocentes,
+          clases,
+        });
+        materia.cursos.push(cursoCodigo);
       }
-      if (clases.length === 0) {
+
+      if (materia.cursos.length === 0) {
         continue;
       }
-      result.cursos.push({
-        materia: materia.codigo,
-        codigo,
-        docentes,
-        clases,
-      });
-      materia.cursos.push(codigo);
-    }
-    if (materia.cursos.length === 0) {
-      continue;
+      periodo.materias.push(materia);
     }
 
-    result.materias.push(materia);
+    if (periodo.materias.length === 0) {
+      continue;
+    }
+    result.push({
+      periodo: periodo.periodo,
+      materias: periodo.materias,
+      cursos: periodo.cursos,
+      timestamp: Date.now(),
+    });
   }
   return result;
 }

--- a/src/siuparser.js
+++ b/src/siuparser.js
@@ -19,7 +19,7 @@ export function parseSIU(rawdata) {
   const periodoPattern =
     /Período lectivo: ([^\n]+)\n((?!Período lectivo:)[\s\S])*?(?=(Período lectivo:|$))/g;
   const materiaPattern =
-    /Actividad: ([^\n]+) \((\d+)\)\n((?!Actividad:)[\s\S])*?(?=(Actividad:|$))/g;
+    /Actividad: ([^\n]+) \((.+?)\)\n((?!Actividad:)[\s\S])*?(?=(Actividad:|$))/g;
   const cursosPattern =
     /Comisión: ([^\n]+)[\s\S]*?Docentes: ([^\n]+)[\s\S]*?Tipo de clase\s+Día\s+Horario\s+Aula([\s\S]*?)(?=(Comisión:|$))/g;
 

--- a/src/siuparser.js
+++ b/src/siuparser.js
@@ -27,6 +27,8 @@ export function parseSIU(rawdata) {
   for (const periodoMatch of rawdata.matchAll(periodoPattern)) {
     const periodoFullText = periodoMatch[0];
     const periodoNombre = periodoMatch[1];
+
+    console.debug(`Found periodo: ${periodoNombre}`)
     periodos.push({
       periodo: periodoNombre,
       raw: periodoFullText,
@@ -43,13 +45,16 @@ export function parseSIU(rawdata) {
         codigo: materiaMatch[2],
         cursos: [],
       };
+      console.debug(`- Found materia: ${materia.nombre} (${materia.codigo})`)
 
       for (const cursoMatch of materiaFullText.matchAll(cursosPattern)) {
         const cursoCodigo = `${materia.codigo}-${cursoMatch[1]}`;
         const cursoDocentes = cursoMatch[2].trim().replace(/\(.*?\)/g, "");
+        console.debug(`-- Found curso: ${cursoCodigo}`)
 
         const clases = [];
         for (let claseLine of cursoMatch[3].trim().split("\n")) {
+          console.debug(`--- Found clase: ${claseLine}`)
           if (claseLine.includes("Sin definir") || !claseLine.includes("\t")) {
             continue;
           }


### PR DESCRIPTION
Este PR flexibiliza el parser del SIU, ahora fijandose de dividir las materias segun el período lectivo de los horarios. Tuve que reescribir el parser entero, asi que si se puede probar contra otros horarios del SIU que no sean los mios, estaria buenisimo doblechequear que este andando correctamente.

Se puede testear con [siu-fede.txt](https://github.com/FdelMazo/FIUBA-Plan/files/14514000/siu-fede.txt) .

La idea es que cuando cargas los horarios, si tenes mas de un periodo lectivo en el SIU, te salte un `Select` para elegir que periodo usar, y despues eso se use como los horarios del resto de la app.

![image](https://github.com/FdelMazo/FIUBA-Plan/assets/25667102/a6319916-52b2-41fd-8df2-d267244801c5)

También le agrego el timestamp de cargada y un pequeño warning donde antes decía la fecha de actualización

![image](https://github.com/FdelMazo/FIUBA-Plan/assets/25667102/529e5fdd-f0c5-447f-b3f1-70b9ba4d3d68)

