### PR TITLE
Simplify siuparser regex patterns

### DIFF
--- a/src/siuparser.js
+++ b/src/siuparser.js
@@ -17,11 +17,11 @@ export function parseSIU(rawdata) {
   const result = [];
 
   const periodoPattern =
-    /Período lectivo: ([^\n]+)\n((?!Período lectivo:)[\s\S])*?(?=(Período lectivo:|$))/g;
+    /Período lectivo: ([^\n]+)\n[\s\S]*?(?=Período lectivo:|$)/g;
   const materiaPattern =
-    /Actividad: ([^\n]+) \((.+?)\)\n((?!Actividad:)[\s\S])*?(?=(Actividad:|$))/g;
+    /Actividad: ([^\n]+) \((.+?)\)\n[\s\S]*?(?=Actividad:|$)/g;
   const cursosPattern =
-    /Comisión: ([^\n]+)[\s\S]*?Docentes: ([^\n]+)[\s\S]*?Tipo de clase\s+Día\s+Horario\s+Aula([\s\S]*?)(?=(Comisión:|$))/g;
+    /Comisión: ([^\n]+)[\s\S]*?Docentes: ([^\n]+)[\s\S]*?Tipo de clase\s+Día\s+Horario\s+Aula([\s\S]*?)(?=Comisión:|$)/g;
 
   const periodos = [];
   for (const periodoMatch of rawdata.matchAll(periodoPattern)) {


### PR DESCRIPTION
Hola @FdelMazo como andas, en este pr simplifico los regex patterns del siu parser.

- En el caso de los negative lookahead de Periodo lectivo y Actividad funciona sin ellos.
- Tambien saco los group que rodea los negative lookahead y [\s\S] porque la aplicacion no utiliza esos groups, asi que creo que estan de mas.
- Tambien saco los group interior que compara cada lookahead al final de los patterns, porque la aplicacion tampoco utiliza esos groups,

(Utilizo la pagina [regex101.com](https://regex101.com/) con [siu-axel.txt](https://github.com/FdelMazo/FIUBA-Plan/files/14636554/siu-axel.txt), tambien funciona con [siu-fede-tabs.txt](https://github.com/FdelMazo/FIUBA-Plan/files/14636574/siu-fede-tabs.txt))
Por ejemplo un match de periodo pasa de ser asi:
![periodo-before](https://github.com/FdelMazo/FIUBA-Plan/assets/96202715/5cf008e7-7cf5-4c3f-8569-248d6cbf0c35)

A ser asi:
![periodo-after](https://github.com/FdelMazo/FIUBA-Plan/assets/96202715/51a40a0e-4cc8-44b4-bbb3-4823d216d238)