### PR TITLE
Allow users to use FIUBA-Plan without using the SIU scraper

### DIFF
--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -57,17 +57,27 @@ const Body = () => {
 
       {isChristmasTime && <Snowfall color="lavender" />}
       <Calendar events={events} useAgenda={useAgenda} />
-      
-      {/* Contenedor para los botones flotantes */}
-      <Box position="absolute" right={10} bottom={10} display="flex" flexDirection="column" gap={2}>
-        {/* Botón de Cargar SIU */}
-        <Tooltip label="Cargar horarios del SIU" hasArrow placement="left">
-          <IconButton
-            borderColor="drawerbg"
-            borderWidth={2}
-            icon={
+      <Tooltip
+        label={horariosSIU ? "Agregar Materias" : "Cargar horarios del SIU"}
+        hasArrow
+        placement="top"
+      >
+        <IconButton
+          position="absolute"
+          right={10}
+          bottom={10}
+          borderColor="drawerbg"
+          borderWidth={2}
+          icon={
+            horariosSIU ? (
+              <AddIcon fontWeight="bold" color="drawerbg" />
+            ) : (
               <Icon viewBox="0 0 268 268" boxSize={8}>
-                <g transform="translate(0,268) scale(0.100000,-0.100000)" fill="black" stroke="none">
+                <g
+                  transform="translate(0,268) scale(0.100000,-0.100000)"
+                  fill="black"
+                  stroke="none"
+                >
                   <path
                     d="M360 1976 c-87 -23 -166 -89 -211 -178 -33 -64 -38 -185 -10 -259 30
 -79 88 -141 168 -181 l65 -32 212 -5 c229 -7 242 -10 285 -70 51 -72 47 -161
@@ -89,25 +99,15 @@ c0 -142 5 -285 11 -318 39 -217 230 -384 458 -400 229 -17 444 128 511 343 19
                   <path d="M1240 1185 l0 -485 130 0 130 0 0 485 0 485 -130 0 -130 0 0 -485z" />
                 </g>
               </Icon>
-            }
-            onClick={onToggleModal}
-            colorScheme="primary"
-            aria-label="Cargar horarios del SIU"
-          />
-        </Tooltip>
-
-        {/* Botón de Agregar Materias */}
-        <Tooltip label="Agregar Materias" hasArrow placement="left">
-          <IconButton
-            borderColor="drawerbg"
-            borderWidth={2}
-            icon={<AddIcon fontWeight="bold" color="drawerbg" />}
-            onClick={onToggleDrawer}
-            colorScheme="primary"
-            aria-label="Agregar Materias"
-          />
-        </Tooltip>
-      </Box>
+            )
+          }
+          onClick={horariosSIU ? onToggleDrawer : onToggleModal}
+          colorScheme="primary"
+          aria-label={
+            horariosSIU ? "Agregar Materias" : "Cargar horarios del SIU"
+          }
+        />
+      </Tooltip>
     </Box>
   );
 };

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -57,27 +57,17 @@ const Body = () => {
 
       {isChristmasTime && <Snowfall color="lavender" />}
       <Calendar events={events} useAgenda={useAgenda} />
-      <Tooltip
-        label={horariosSIU ? "Agregar Materias" : "Cargar horarios del SIU"}
-        hasArrow
-        placement="top"
-      >
-        <IconButton
-          position="absolute"
-          right={10}
-          bottom={10}
-          borderColor="drawerbg"
-          borderWidth={2}
-          icon={
-            horariosSIU ? (
-              <AddIcon fontWeight="bold" color="drawerbg" />
-            ) : (
+      
+      {/* Contenedor para los botones flotantes */}
+      <Box position="absolute" right={10} bottom={10} display="flex" flexDirection="column" gap={2}>
+        {/* Botón de Cargar SIU */}
+        <Tooltip label="Cargar horarios del SIU" hasArrow placement="left">
+          <IconButton
+            borderColor="drawerbg"
+            borderWidth={2}
+            icon={
               <Icon viewBox="0 0 268 268" boxSize={8}>
-                <g
-                  transform="translate(0,268) scale(0.100000,-0.100000)"
-                  fill="black"
-                  stroke="none"
-                >
+                <g transform="translate(0,268) scale(0.100000,-0.100000)" fill="black" stroke="none">
                   <path
                     d="M360 1976 c-87 -23 -166 -89 -211 -178 -33 -64 -38 -185 -10 -259 30
 -79 88 -141 168 -181 l65 -32 212 -5 c229 -7 242 -10 285 -70 51 -72 47 -161
@@ -99,15 +89,25 @@ c0 -142 5 -285 11 -318 39 -217 230 -384 458 -400 229 -17 444 128 511 343 19
                   <path d="M1240 1185 l0 -485 130 0 130 0 0 485 0 485 -130 0 -130 0 0 -485z" />
                 </g>
               </Icon>
-            )
-          }
-          onClick={horariosSIU ? onToggleDrawer : onToggleModal}
-          colorScheme="primary"
-          aria-label={
-            horariosSIU ? "Agregar Materias" : "Cargar horarios del SIU"
-          }
-        />
-      </Tooltip>
+            }
+            onClick={onToggleModal}
+            colorScheme="primary"
+            aria-label="Cargar horarios del SIU"
+          />
+        </Tooltip>
+
+        {/* Botón de Agregar Materias */}
+        <Tooltip label="Agregar Materias" hasArrow placement="left">
+          <IconButton
+            borderColor="drawerbg"
+            borderWidth={2}
+            icon={<AddIcon fontWeight="bold" color="drawerbg" />}
+            onClick={onToggleDrawer}
+            colorScheme="primary"
+            aria-label="Agregar Materias"
+          />
+        </Tooltip>
+      </Box>
     </Box>
   );
 };

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -44,7 +44,7 @@ const Body = () => {
     localStorage.setItem('skipSIU', JSON.stringify(skipSIU));
   }, [skipSIU]);
 
-  useHotkeys("esc", horariosSIU ? onToggleDrawer : onToggleModal, {
+  useHotkeys("esc", (horariosSIU || skipSIU) ? onToggleDrawer : onToggleModal, {
     enableOnFormTags: true,
   });
 

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -25,6 +25,7 @@ const isChristmasTime = today >= start && today <= end;
 const Body = () => {
   const { events, horariosSIU } = React.useContext(DataContext);
   const [useAgenda, setUseAgenda] = React.useState(false);
+  const [skipSIU, setSkipSIU] = React.useState(false);
   const { width } = useWindowSize();
   const {
     isOpen: isOpenDrawer,
@@ -53,61 +54,66 @@ const Body = () => {
         useAgenda={useAgenda}
         setUseAgenda={setUseAgenda}
       />
-      <ManualUploadModal isOpen={isOpenModal} onClose={onCloseModal} />
+      <ManualUploadModal 
+        isOpen={isOpenModal} 
+        onClose={onCloseModal}
+        onSkip={() => setSkipSIU(true)}
+      />
 
       {isChristmasTime && <Snowfall color="lavender" />}
       <Calendar events={events} useAgenda={useAgenda} />
-      <Tooltip
-        label={horariosSIU ? "Agregar Materias" : "Cargar horarios del SIU"}
-        hasArrow
-        placement="top"
-      >
-        <IconButton
-          position="absolute"
-          right={10}
-          bottom={10}
-          borderColor="drawerbg"
-          borderWidth={2}
-          icon={
-            horariosSIU ? (
-              <AddIcon fontWeight="bold" color="drawerbg" />
-            ) : (
-              <Icon viewBox="0 0 268 268" boxSize={8}>
-                <g
-                  transform="translate(0,268) scale(0.100000,-0.100000)"
-                  fill="black"
-                  stroke="none"
-                >
-                  <path
-                    d="M360 1976 c-87 -23 -166 -89 -211 -178 -33 -64 -38 -185 -10 -259 30
+      
+      <Box position="absolute" right={10} bottom={10} display="flex" flexDirection="column" gap={2}>
+        {!horariosSIU && !skipSIU && (
+          <Tooltip label="Cargar horarios del SIU" hasArrow placement="left">
+            <IconButton
+              borderColor="drawerbg"
+              borderWidth={2}
+              icon={
+                <Icon viewBox="0 0 268 268" boxSize={8}>
+                  <g transform="translate(0,268) scale(0.100000,-0.100000)" fill="black" stroke="none">
+                    <path
+                      d="M360 1976 c-87 -23 -166 -89 -211 -178 -33 -64 -38 -185 -10 -259 30
 -79 88 -141 168 -181 l65 -32 212 -5 c229 -7 242 -10 285 -70 51 -72 47 -161
 -12 -228 -54 -62 -63 -63 -402 -63 l-305 0 0 -130 0 -130 305 0 c187 0 324 4
 357 11 131 28 248 121 309 244 33 67 34 74 34 185 0 114 -1 118 -37 191 -46
 93 -122 168 -215 212 l-68 32 -207 5 c-196 5 -209 6 -229 27 -28 28 -27 68 1
 99 l23 24 369 0 368 0 0 103 c-1 106 -6 124 -47 145 -31 17 -691 15 -753 -2z"
-                  />
-                  <path
-                    d="M1230 1971 c5 -11 10 -69 10 -130 l0 -111 295 0 295 0 0 101 c0 55
+                    />
+                    <path
+                      d="M1230 1971 c5 -11 10 -69 10 -130 l0 -111 295 0 295 0 0 101 c0 55
 -4 109 -10 119 -18 34 -65 40 -337 40 -258 0 -263 0 -253 -19z"
-                  />
-                  <path
-                    d="M2320 1582 c0 -339 -3 -417 -15 -460 -39 -129 -175 -200 -309 -160
+                    />
+                    <path
+                      d="M2320 1582 c0 -339 -3 -417 -15 -460 -39 -129 -175 -200 -309 -160
 -56 17 -141 100 -155 153 -7 24 -11 143 -11 298 l0 257 -130 0 -130 0 0 -258
 c0 -142 5 -285 11 -318 39 -217 230 -384 458 -400 229 -17 444 128 511 343 19
 61 20 93 20 509 l0 444 -125 0 -125 0 0 -408z"
-                  />
-                  <path d="M1240 1185 l0 -485 130 0 130 0 0 485 0 485 -130 0 -130 0 0 -485z" />
-                </g>
-              </Icon>
-            )
-          }
-          onClick={horariosSIU ? onToggleDrawer : onToggleModal}
-          colorScheme="primary"
-          aria-label={
-            horariosSIU ? "Agregar Materias" : "Cargar horarios del SIU"
-          }
-        />
-      </Tooltip>
+                    />
+                    <path d="M1240 1185 l0 -485 130 0 130 0 0 485 0 485 -130 0 -130 0 0 -485z" />
+                  </g>
+                </Icon>
+              }
+              onClick={onToggleModal}
+              colorScheme="primary"
+              aria-label="Cargar horarios del SIU"
+            />
+          </Tooltip>
+        )}
+
+        {(horariosSIU || skipSIU) && (
+          <Tooltip label="Agregar Materias" hasArrow placement="left">
+            <IconButton
+              borderColor="drawerbg"
+              borderWidth={2}
+              icon={<AddIcon fontWeight="bold" color="drawerbg" />}
+              onClick={onToggleDrawer}
+              colorScheme="primary"
+              aria-label="Agregar Materias"
+            />
+          </Tooltip>
+        )}
+      </Box>
     </Box>
   );
 };

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -38,7 +38,7 @@ const Body = () => {
     onClose: onCloseModal,
   } = useDisclosure();
 
-  useHotkeys("esc", horariosSIU ? onToggleDrawer : onToggleModal, {
+  useHotkeys("esc", horariosSIU || skipSIU ? onToggleDrawer : onToggleModal, {
     enableOnFormTags: true,
   });
 
@@ -67,7 +67,7 @@ const Body = () => {
       <Calendar events={events} useAgenda={useAgenda} />
       
       <Box position="absolute" right={10} bottom={10} display="flex" flexDirection="column" gap={2}>
-        {!horariosSIU && !skipSIU && (
+        {(!horariosSIU && !skipSIU) ? (
           <Tooltip label="Cargar horarios del SIU" hasArrow placement="left">
             <IconButton
               borderColor="drawerbg"
@@ -102,9 +102,7 @@ c0 -142 5 -285 11 -318 39 -217 230 -384 458 -400 229 -17 444 128 511 343 19
               aria-label="Cargar horarios del SIU"
             />
           </Tooltip>
-        )}
-
-        {(horariosSIU || skipSIU) && (
+        ) : (
           <Tooltip label="Agregar Materias" hasArrow placement="left">
             <IconButton
               borderColor="drawerbg"

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -53,11 +53,14 @@ const Body = () => {
         onClose={onCloseDrawer}
         useAgenda={useAgenda}
         setUseAgenda={setUseAgenda}
+        skipSIU={skipSIU}
+        onOpenModal={onToggleModal}
       />
       <ManualUploadModal 
         isOpen={isOpenModal} 
         onClose={onCloseModal}
         onSkip={() => setSkipSIU(true)}
+        setSkipSIU={setSkipSIU}
       />
 
       {isChristmasTime && <Snowfall color="lavender" />}

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -25,7 +25,9 @@ const isChristmasTime = today >= start && today <= end;
 const Body = () => {
   const { events, horariosSIU } = React.useContext(DataContext);
   const [useAgenda, setUseAgenda] = React.useState(false);
-  const [skipSIU, setSkipSIU] = React.useState(false);
+  const [skipSIU, setSkipSIU] = React.useState(() => 
+    JSON.parse(localStorage.getItem('skipSIU')) || false
+  );
   const { width } = useWindowSize();
   const {
     isOpen: isOpenDrawer,
@@ -38,7 +40,11 @@ const Body = () => {
     onClose: onCloseModal,
   } = useDisclosure();
 
-  useHotkeys("esc", horariosSIU || skipSIU ? onToggleDrawer : onToggleModal, {
+  React.useEffect(() => {
+    localStorage.setItem('skipSIU', JSON.stringify(skipSIU));
+  }, [skipSIU]);
+
+  useHotkeys("esc", horariosSIU ? onToggleDrawer : onToggleModal, {
     enableOnFormTags: true,
   });
 

--- a/src/components/ManualUploadModal.js
+++ b/src/components/ManualUploadModal.js
@@ -15,6 +15,7 @@ import {
   Text,
   Textarea,
   useToast,
+  Flex,
 } from "@chakra-ui/react";
 import React from "react";
 import { DataContext } from "../DataContext";
@@ -103,55 +104,67 @@ const ManualUploadModal = ({ isOpen, onClose }) => {
               ))}
             </Select>
           )}
-          {periodosOptions.length > 0 ? (
-            <Button
-              w="100%"
-              colorScheme="primary"
-              isDisabled={!selectedPeriod}
-              onClick={() => {
-                const periodo = periodosOptions.find(
-                  (p) => p.periodo === selectedPeriod
-                );
-                applyHorariosSIU(periodo);
-                onClose();
-                toast({
-                  title: "Horarios del SIU aplicados",
-                  status: "success",
-                  duration: 2000,
-                  isClosable: true,
-                });
-              }}
-            >
-              Aplicar horarios
-            </Button>
-          ) : (
-            <Button
-              w="100%"
-              colorScheme="primary"
-              isDisabled={!siuData}
-              onClick={() => {
-                try {
-                  const periodos = getPeriodosSIU(siuData);
-                  if (periodos.length > 1) {
-                    setPeriodosOptions(periodos);
-                  } else {
-                    applyHorariosSIU(periodos[0]);
-                    onClose();
-                    toast({
-                      title: "Horarios del SIU aplicados",
-                      status: "success",
-                      duration: 2000,
-                      isClosable: true,
-                    });
+
+          <Flex gap={4} my={4}>
+            {periodosOptions.length > 0 ? (
+              <Button
+                flex={1}
+                colorScheme="primary"
+                isDisabled={!selectedPeriod}
+                onClick={() => {
+                  const periodo = periodosOptions.find(
+                    (p) => p.periodo === selectedPeriod
+                  );
+                  applyHorariosSIU(periodo);
+                  onClose();
+                  toast({
+                    title: "Horarios del SIU aplicados",
+                    status: "success",
+                    duration: 2000,
+                    isClosable: true,
+                  });
+                }}
+              >
+                Cargar horarios
+              </Button>
+            ) : (
+              <Button
+                flex={1}
+                colorScheme="primary"
+                isDisabled={!siuData}
+                onClick={() => {
+                  try {
+                    const periodos = getPeriodosSIU(siuData);
+                    if (periodos.length > 1) {
+                      setPeriodosOptions(periodos);
+                    } else {
+                      applyHorariosSIU(periodos[0]);
+                      onClose();
+                      toast({
+                        title: "Horarios del SIU aplicados",
+                        status: "success",
+                        duration: 2000,
+                        isClosable: true,
+                      });
+                    }
+                  } catch (e) {
+                    setError(e.message);
                   }
-                } catch (e) {
-                  setError(e.message);
-                }
-              }}
+                }}
+              >
+                Cargar horarios
+              </Button>
+            )}
+
+            <Button
+              flex={1}
+              variant="outline"
+              onClick={onClose}
             >
-              Cargar horarios
+              Seguir sin importar
             </Button>
-          )}
+          </Flex>
+
           {error && (
             <Text size="sm" color="tomato">
               {error}

--- a/src/components/ManualUploadModal.js
+++ b/src/components/ManualUploadModal.js
@@ -116,7 +116,7 @@ const ManualUploadModal = ({ isOpen, onClose, onSkip, setSkipSIU }) => {
             </Select>
           )}
 
-          <Flex gap={4} my={4}>
+          <Flex gap={2} my={4}>
             {periodosOptions.length > 0 ? (
               <Button
                 flex={1}
@@ -130,7 +130,7 @@ const ManualUploadModal = ({ isOpen, onClose, onSkip, setSkipSIU }) => {
                   handleSuccessfulUpload();
                 }}
               >
-                Cargar horarios
+                Agregar horarios
               </Button>
             ) : (
               <Button

--- a/src/components/ManualUploadModal.js
+++ b/src/components/ManualUploadModal.js
@@ -20,7 +20,7 @@ import {
 import React from "react";
 import { DataContext } from "../DataContext";
 
-const ManualUploadModal = ({ isOpen, onClose }) => {
+const ManualUploadModal = ({ isOpen, onClose, onSkip }) => {
   const toast = useToast();
   const [error, setError] = React.useState("");
   const [siuData, setSiuData] = React.useState("");
@@ -159,7 +159,10 @@ const ManualUploadModal = ({ isOpen, onClose }) => {
             <Button
               flex={1}
               variant="outline"
-              onClick={onClose}
+              onClick={() => {
+                onSkip();
+                onClose();
+              }}
             >
               Seguir sin importar
             </Button>

--- a/src/components/ManualUploadModal.js
+++ b/src/components/ManualUploadModal.js
@@ -20,13 +20,24 @@ import {
 import React from "react";
 import { DataContext } from "../DataContext";
 
-const ManualUploadModal = ({ isOpen, onClose, onSkip }) => {
+const ManualUploadModal = ({ isOpen, onClose, onSkip, setSkipSIU }) => {
   const toast = useToast();
   const [error, setError] = React.useState("");
   const [siuData, setSiuData] = React.useState("");
   const [periodosOptions, setPeriodosOptions] = React.useState([]);
   const [selectedPeriod, setSelectedPeriod] = React.useState(null);
   const { applyHorariosSIU, getPeriodosSIU } = React.useContext(DataContext);
+
+  const handleSuccessfulUpload = () => {
+    setSkipSIU(false);
+    onClose();
+    toast({
+      title: "Horarios del SIU aplicados",
+      status: "success",
+      duration: 2000,
+      isClosable: true,
+    });
+  };
 
   return (
     <Modal
@@ -116,13 +127,7 @@ const ManualUploadModal = ({ isOpen, onClose, onSkip }) => {
                     (p) => p.periodo === selectedPeriod
                   );
                   applyHorariosSIU(periodo);
-                  onClose();
-                  toast({
-                    title: "Horarios del SIU aplicados",
-                    status: "success",
-                    duration: 2000,
-                    isClosable: true,
-                  });
+                  handleSuccessfulUpload();
                 }}
               >
                 Cargar horarios
@@ -139,13 +144,7 @@ const ManualUploadModal = ({ isOpen, onClose, onSkip }) => {
                       setPeriodosOptions(periodos);
                     } else {
                       applyHorariosSIU(periodos[0]);
-                      onClose();
-                      toast({
-                        title: "Horarios del SIU aplicados",
-                        status: "success",
-                        duration: 2000,
-                        isClosable: true,
-                      });
+                      handleSuccessfulUpload();
                     }
                   } catch (e) {
                     setError(e.message);

--- a/src/components/MateriasDrawer.js
+++ b/src/components/MateriasDrawer.js
@@ -75,7 +75,6 @@ const MateriasDrawer = (props) => {
             {skipSIU ? (
               <Button
                 w="100%"
-                rightIcon={<CalendarIcon />}
                 colorScheme="primary"
                 onClick={() => {
                   onClose();

--- a/src/components/MateriasDrawer.js
+++ b/src/components/MateriasDrawer.js
@@ -35,7 +35,7 @@ import SelectMateria from "./SelectMateria";
 import Sugerencias from "./Sugerencias";
 
 const MateriasDrawer = (props) => {
-  const { useAgenda, setUseAgenda, isOpen, onClose } = props;
+  const { useAgenda, setUseAgenda, isOpen, onClose, skipSIU, onOpenModal } = props;
   const {
     tabs,
     selectedMaterias,
@@ -72,17 +72,33 @@ const MateriasDrawer = (props) => {
           bg={useColorModeValue("drawerbgalpha", "drawerbgdarkalpha")}
         >
           <Box pt={4} px={4}>
-            <Button
-              w="100%"
-              rightIcon={<DeleteIcon />}
-              colorScheme="red"
-              onClick={async () => {
-                await removeHorariosSIU();
-                onClose();
-              }}
-            >
-              Dejar de usar horarios del SIU
-            </Button>
+            {skipSIU ? (
+              <Button
+                w="100%"
+                rightIcon={<CalendarIcon />}
+                colorScheme="primary"
+                onClick={() => {
+                  onClose();
+                  onOpenModal();
+                }}
+              >
+                Cargar horarios del SIU
+              </Button>
+            ) : (
+              horariosSIU && (
+                <Button
+                  w="100%"
+                  rightIcon={<DeleteIcon />}
+                  colorScheme="red"
+                  onClick={async () => {
+                    await removeHorariosSIU();
+                    onClose();
+                  }}
+                >
+                  Dejar de usar horarios del SIU
+                </Button>
+              )
+            )}
           </Box>
 
           <Box px={6}>


### PR DESCRIPTION
Agrego esta función porque uso el calendario con materias que no son de SIU y solo me permitía ponerles nombre si importaba los horarios de SIU.
Antes no se podía acceder a la edición del nombre del segmento agregado:
![image](https://github.com/user-attachments/assets/be05be56-c8a7-471f-861a-38640021d6ac)

Despues:
![image](https://github.com/user-attachments/assets/6018a796-1bec-4cdc-bb30-cf2869f17018)

![image](https://github.com/user-attachments/assets/22066d72-404c-4772-b441-23705ed62cc4)


