### PR TITLE
➕ When a new tab is created, shift focus to it automatically

### DIFF
--- a/src/DataContext.js
+++ b/src/DataContext.js
@@ -333,6 +333,7 @@ const Data = () => {
     }
     tabsDispatch({ type: "add", id });
     tabEventsDispatch({ type: "resetTab", tabId: id });
+    selectTab(id);
   };
 
   const renameTab = (id, title) => {


### PR DESCRIPTION
Why? For students to feel an experience they are already accustomed to: **when people create new tabs in web browser, file managers, etc., they are usually moved to that tab immediately**. So, I replicated that experience within this project.