### PR TITLE
When removing a tab, select the previous one to the left, not the first one

### DIFF
--- a/src/DataContext.js
+++ b/src/DataContext.js
@@ -343,14 +343,7 @@ const Data = () => {
   const removeTab = (id) => {
     tabsDispatch({ type: "remove", id });
     tabEventsDispatch({ type: "removeTab", tabId: id });
-
-    // Select previous tab to the left.
-    const ids = tabs.map((t) => t.id);
-    let i = id - 1;
-    while (!ids.includes(i)) {
-      i -= 1;
-    }
-    selectTab(i);
+    selectTab(tabs.map((t) => t.id).indexOf(id) - 1);
   };
 
   // Los eventos a mostrar en el calendario son todos los cursos seleccionados por el usuario


### PR DESCRIPTION
In order to get an experience a little more similar to what we all experience when web browsing.