### PR TITLE
Added support to close the first and/or only-one-left tab

### DIFF
--- a/src/DataContext.js
+++ b/src/DataContext.js
@@ -341,14 +341,15 @@ const Data = () => {
   };
 
   const removeTab = (id) => {
+    tabsDispatch({ type: "remove", id });
+    tabEventsDispatch({ type: "removeTab", tabId: id });
+
     if (tabs.length === 1) {
       addTab();
     } else {
       const index = tabs.map((t) => t.id).indexOf(id);
       selectTab(tabs[index > 0 ? index - 1 : index + 1].id);
     };
-    tabsDispatch({ type: "remove", id });
-    tabEventsDispatch({ type: "removeTab", tabId: id });
   };
 
   // Los eventos a mostrar en el calendario son todos los cursos seleccionados por el usuario

--- a/src/DataContext.js
+++ b/src/DataContext.js
@@ -341,7 +341,12 @@ const Data = () => {
   };
 
   const removeTab = (id) => {
-    selectTab(tabs[tabs.map((t) => t.id).indexOf(id) - 1].id);
+    if (tabs.length === 1) {
+      addTab();
+    } else {
+      const index = tabs.map((t) => t.id).indexOf(id);
+      selectTab(tabs[index > 0 ? index - 1 : index + 1].id);
+    };
     tabsDispatch({ type: "remove", id });
     tabEventsDispatch({ type: "removeTab", tabId: id });
   };

--- a/src/components/MateriasDrawer.js
+++ b/src/components/MateriasDrawer.js
@@ -194,7 +194,7 @@ const MateriasDrawer = (props) => {
 
             <Box textAlign="right">
               <Tooltip
-                label={`${useColorModeValue("Dark", "Light")} theme`}
+                label={`Tema ${useColorModeValue("oscuro", "claro")}`}
                 placement="top"
               >
                 <Link color="primary.600" onClick={toggleColorMode}>

--- a/src/components/TabSystem.js
+++ b/src/components/TabSystem.js
@@ -257,7 +257,7 @@ const CustomTab = React.forwardRef((props, ref) => {
               boxShadow: "0 0 0 3px rgba(183,148,244, 0.6)",
             }}
           />
-          {props.tab.id !== 0 && isSelected && (
+          {isSelected && (
             <SmallCloseIcon
               _hover={{ color: "primary.900" }}
               boxSize="20px"


### PR DESCRIPTION
Antes no podías eliminar la primera pestaña (ya sea que sea la única que quede, o con más pestañas abiertas). Esto volvía complicada la cuestión si querías “vaciar todo y empezar de cero”. Claro que igualmente tenés ya la opción de _limpiar plan_, pero eso no te resetea el nombre de la pestaña ni se puede hacer si aún no importaste horarios del SIU (sí, en el raro caso que alguien se haya puesto a agregar actividades extracurriculares antes que los horarios de la facu).

Por lo menos a mí, siempre se me hizo raro que de repente haya una pestaña que no pueda cerrar. _Like, why?_

Por otro lado, es común en los navegadores (el software por excelencia que usa _tab systems_, y al que todos más acostumbrados estamos) que puedas cerrar una pestaña más allá de si es la única que queda. En esos casos, se suele cerrar el navegador o automáticamente crea una nueva. Como obviamente no vamos a cerrarle FIUBA Plan al usuario, tomé el camino de automáticamente abrirle una nueva, para que ahí el loco pueda seguir con su planificación tranquilamente.

---

Estuve probando este cambio que le hice y lo vengo sintiendo superintuitivo el comportamiento; ¡espero se sienta igual para vos, Fede! (Y para la gente, ¡claro!)